### PR TITLE
Increase MaxMessagePaload size to 512MB

### DIFF
--- a/wire/message.go
+++ b/wire/message.go
@@ -24,7 +24,7 @@ const CommandSize = 12
 
 // MaxMessagePayload is the maximum bytes a message can be regardless of other
 // individual limits imposed by messages themselves.
-const MaxMessagePayload = (1024 * 1024 * 32) // 32MB
+const MaxMessagePayload = (1024 * 1024 * 512) // 512MB
 
 // Commands used in bitcoin message headers which describe the type of message.
 const (


### PR DESCRIPTION
A 64MB block now exists on the network, with the intention of larger blocks in the near future.

This PR raises the limit to 512MB.

If the intention is for block sizes to continue to increase, is it worth removing the check against `MaxMessagePayload` to avoid further PR's that will either proactively or reactively (after failure) raise the limit? I'm happy to open an issue for this.