### PR TITLE
Raise MaxBlockPayload to 128MB.

### DIFF
--- a/wire/msgalert_test.go
+++ b/wire/msgalert_test.go
@@ -38,7 +38,7 @@ func TestMsgAlert(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value.
-	wantPayload := uint32(1024 * 1024 * 32)
+	wantPayload := uint32(MaxMessagePayload)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -23,7 +23,7 @@ const defaultTransactionAlloc = 2048
 const MaxBlocksPerMsg = 500
 
 // MaxBlockPayload is the maximum bytes a block message can be in bytes.
-const MaxBlockPayload = 32000000 // Not actually 1MB which would be 1024 * 1024
+const MaxBlockPayload = 128 * 1024 * 1024
 
 // maxTxPerBlock is the maximum number of transactions that could
 // possibly fit into a block.

--- a/wire/msgblock_test.go
+++ b/wire/msgblock_test.go
@@ -36,7 +36,7 @@ func TestBlock(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
-	wantPayload := uint32(1000000)
+	wantPayload := uint32(MaxBlockPayload)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -36,7 +36,7 @@ func TestTx(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
-	wantPayload := uint32(1000 * 1000)
+	wantPayload := uint32(MaxBlockPayload)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+


### PR DESCRIPTION
This had an impact on the maxTxPerBlock as well.

The limit checks are still there, but this raises it from ~32MB to 128MB.

TestMerkleBlock was refactored to use a smaller number of hashes. Limits are now tested in other tests.